### PR TITLE
Limit stats in time

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v3

--- a/__mocks__/db.js
+++ b/__mocks__/db.js
@@ -87,6 +87,7 @@ module.exports = {
   setEndTime: jest.fn(async (instanceRef, timezone) => {}),
   setStartTime: jest.fn(async (instanceRef, timezone) => {}),
   setTimezone: jest.fn(async (instanceRef, timezone) => {}),
+  setUserSetting: jest.fn(async (instanceRef, userRef, name, value) => {}),
   setWeekdays: jest.fn(async (instanceRef, weekdayMask) => {}),
   scheduled: jest.fn(async (instanceRef) => {}),
   storeScheduled: jest.fn(async (instanceRef, timestamp, messageId, channel) => {}),
@@ -96,5 +97,6 @@ module.exports = {
   }),
   async recentClickTimes () { return [] },
   async slowestClickTimes (instanceRef) { return [] },
+  async userSettings (instanceRef, userRef) { return {} },
   async winningStreaks (instanceRef) { return [{ user: 'test1', streak: 3 }] }
 }

--- a/__tests__/db.test.js
+++ b/__tests__/db.test.js
@@ -263,6 +263,9 @@ describe('database', () => {
         authedUser: {
           id: 'U9'
         },
+        userSettings: {
+          U1: { statsInterval: 7 }
+        },
         channel: 'C1',
         scheduled: {}
       }
@@ -341,6 +344,14 @@ describe('database', () => {
       expect(clicks).toEqual([
         { user: 'U12341234', time: 1000 },
         { user: 'U12341234', time: 2000 },
+        { user: 'U99991111', time: 4000 }
+      ])
+    })
+
+    test('is sorted and correct when user has limited stats', async () => {
+      const clicks = await db.fastestClickTimes('T2', 10, 'U1', DateTime.fromISO('2020-03-22T00:00:00.000Z').toUTC())
+      expect(clicks).toEqual([
+        { user: 'U12341234', time: 1000 },
         { user: 'U99991111', time: 4000 }
       ])
     })
@@ -1424,6 +1435,9 @@ describe('database', () => {
         authedUser: {
           id: 'U9'
         },
+        userSettings: {
+          U1: { statsInterval: 7 }
+        },
         channel: 'C1',
         scheduled: {}
       }
@@ -1502,6 +1516,14 @@ describe('database', () => {
       expect(clicks).toEqual([
         { user: 'U99991111', time: 4000 },
         { user: 'U12341234', time: 2000 },
+        { user: 'U12341234', time: 1000 }
+      ])
+    })
+
+    test('is sorted and correct when user has limited stats', async () => {
+      const clicks = await db.slowestClickTimes('T2', 10, 'U1', DateTime.fromISO('2020-03-22T00:00:00.000Z').toUTC())
+      expect(clicks).toEqual([
+        { user: 'U99991111', time: 4000 },
         { user: 'U12341234', time: 1000 }
       ])
     })
@@ -1785,6 +1807,9 @@ describe('database', () => {
         authedUser: {
           id: 'U9'
         },
+        userSettings: {
+          U1: { statsInterval: 7 }
+        },
         channel: 'C1',
         scheduled: {}
       }
@@ -1887,6 +1912,15 @@ describe('database', () => {
       expect(clicks).toEqual([
         { user: 'U12341234', streak: 3 },
         { user: 'U12341234', streak: 2 },
+        { user: 'U99991111', streak: 1 }
+      ])
+    })
+
+    test('is sorted and correct when stats interval is limited', async () => {
+      const clicks = await db.winningStreaks('T2', 10, 'U1', DateTime.fromISO('2020-03-22T00:00:00.000Z').toUTC())
+      expect(clicks).toEqual([
+        { user: 'U12341234', streak: 3 },
+        { user: 'U12341234', streak: 1 },
         { user: 'U99991111', streak: 1 }
       ])
     })

--- a/__tests__/db.test.js
+++ b/__tests__/db.test.js
@@ -134,6 +134,10 @@ describe('database', () => {
         authedUser: {
           id: 'U9'
         },
+        userSettings: {
+          U1: { statsInterval: 0 },
+          U2: { statsInterval: 7 }
+        },
         channel: 'C1',
         scheduled: {}
       }
@@ -211,6 +215,30 @@ describe('database', () => {
       const clicks = await db.clicksPerUser('T2')
       expect(clicks).toEqual([
         { user: 'U12341234', count: 2 },
+        { user: 'U99991111', count: 1 }
+      ])
+    })
+
+    test('is sorted and correct no interval stats set', async () => {
+      const clicks = await db.clicksPerUser('T2', 'U0')
+      expect(clicks).toEqual([
+        { user: 'U12341234', count: 2 },
+        { user: 'U99991111', count: 1 }
+      ])
+    })
+
+    test('is sorted and correct last forever stats', async () => {
+      const clicks = await db.clicksPerUser('T2', 'U1')
+      expect(clicks).toEqual([
+        { user: 'U12341234', count: 2 },
+        { user: 'U99991111', count: 1 }
+      ])
+    })
+
+    test('is sorted and correct last 7 days stats', async () => {
+      const clicks = await db.clicksPerUser('T2', 'U2', DateTime.fromISO('2020-03-22T00:00:00.000Z').toUTC())
+      expect(clicks).toEqual([
+        { user: 'U12341234', count: 1 },
         { user: 'U99991111', count: 1 }
       ])
     })
@@ -1577,6 +1605,164 @@ describe('database', () => {
       })
 
       expect(instance.scheduled).toEqual({})
+    })
+  })
+
+  describe('userSettings', () => {
+    beforeEach(async () => {
+      const collection = await db._instanceCollection()
+      await collection.deleteMany({})
+
+      // For each of these tests, initialize the db with some contents.
+      const instanceCommon = {
+        accessToken: 'xoxop-134234234',
+        manualAnnounce: false,
+        weekdays: 0,
+        intervalStart: 32400,
+        intervalEnd: 57600,
+        timezone: 'Europe/Copenhagen',
+        scope: 'chat:write',
+        botUserId: 'U8',
+        appId: 'A1',
+        authedUser: {
+          id: 'U9'
+        },
+        channel: 'C1',
+        scheduled: {}
+      }
+
+      const instance1 = {
+        ...instanceCommon,
+        team: {
+          id: 'T1',
+          name: 'Team1'
+        },
+        userSettings: {
+          U1234: {
+            statsInterval: 365
+          }
+        }
+      }
+
+      const instance2 = {
+        ...instanceCommon,
+        team: {
+          id: 'T2',
+          name: 'Team2'
+        }
+      }
+
+      await collection.insertMany([instance1, instance2])
+    })
+
+    test('is empty when no user settings exists', async () => {
+      const clicks = await db.userSettings('T2', 'U1234')
+      expect(clicks).toEqual({})
+    })
+
+    test('is empty when user does not exists', async () => {
+      const clicks = await db.userSettings('T1', 'U0000')
+      expect(clicks).toEqual({})
+    })
+
+    test('is not empty when user exists', async () => {
+      const clicks = await db.userSettings('T1', 'U1234')
+      expect(clicks).toEqual({ statsInterval: 365 })
+    })
+  })
+
+  describe('setUserSetting', () => {
+    beforeEach(async () => {
+      const collection = await db._instanceCollection()
+      await collection.deleteMany({})
+
+      // For each of these tests, initialize the db with some contents.
+      const sharedProperties = {
+        accessToken: 'xoxop-134234234',
+        manualAnnounce: false,
+        weekdays: 0,
+        intervalStart: 32400,
+        intervalEnd: 57600,
+        timezone: 'Europe/Copenhagen',
+        scope: 'chat:write',
+        botUserId: 'U8',
+        appId: 'A1',
+        authedUser: {
+          id: 'U9'
+        },
+        buttons: []
+      }
+
+      await collection.insertMany([{
+        ...sharedProperties,
+        team: {
+          id: 'T1',
+          name: 'Team1'
+        },
+        userSettings: {
+          U1: {},
+          U2: {
+            statsInterval: 1
+          }
+        },
+        channel: null,
+        scheduled: {}
+      }, {
+        ...sharedProperties,
+        team: {
+          id: 'T2',
+          name: 'Team1'
+        },
+        // missing userSettings completely
+        channel: null,
+        scheduled: {}
+      }])
+    })
+
+    test('stores setting when userSettings does not exists', async () => {
+      await db.setUserSetting('T2', 'U1337', 'statsInterval', 365)
+      const collection = await db._instanceCollection()
+      const instance = await collection.findOne({
+        'team.id': 'T2'
+      })
+
+      expect(instance.userSettings).toEqual({
+        U1337: {
+          statsInterval: 365
+        }
+      })
+    })
+
+    test('stores setting when user does not exists', async () => {
+      await db.setUserSetting('T1', 'U3', 'statsInterval', 365)
+      const collection = await db._instanceCollection()
+      const instance = await collection.findOne({
+        'team.id': 'T1'
+      })
+
+      expect(instance.userSettings).toHaveProperty('U3', { statsInterval: 365 }) // New
+      expect(instance.userSettings).toHaveProperty('U2', { statsInterval: 1 }) // old
+    })
+
+    test('stores setting when user exists but does not have setting', async () => {
+      await db.setUserSetting('T1', 'U1', 'statsInterval', 365)
+      const collection = await db._instanceCollection()
+      const instance = await collection.findOne({
+        'team.id': 'T1'
+      })
+
+      expect(instance.userSettings).toHaveProperty('U1', { statsInterval: 365 }) // New
+      expect(instance.userSettings).toHaveProperty('U2', { statsInterval: 1 }) // old
+    })
+
+    test('stores setting when user exists and has setting', async () => {
+      await db.setUserSetting('T1', 'U2', 'statsInterval', 365)
+      const collection = await db._instanceCollection()
+      const instance = await collection.findOne({
+        'team.id': 'T1'
+      })
+
+      expect(instance.userSettings).toHaveProperty('U2', { statsInterval: 365 }) // New
     })
   })
 

--- a/__tests__/settings.test.js
+++ b/__tests__/settings.test.js
@@ -206,4 +206,30 @@ describe('weekday setting', () => {
     expect(db.setWeekdays.mock.calls[0][1]).toBe(0b0000000)
     expect(res.send).toHaveBeenCalledAfter(db.setWeekdays)
   })
+
+  test('can set stats interval correctly', async () => {
+    const instanceRef = 'T1234'
+    const userRef = 'U1'
+    const action = { // the real object has the complete plain text and stuff for the whole view too.
+      type: 'static_select',
+      action_id: 'user_stats_interval',
+      selected_option: {
+        text: {
+          type: 'plain_text',
+          text: 'Forever',
+          emoji: true
+        },
+        value: '0'
+      }
+    }
+    const res = { send: jest.fn() }
+
+    await settings.setUserSetting(res, instanceRef, action, userRef, 'statsInterval')
+    expect(db.setUserSetting).toHaveBeenCalledTimes(1)
+    expect(db.setUserSetting.mock.calls[0][0]).toBe(instanceRef)
+    expect(db.setUserSetting.mock.calls[0][1]).toBe(userRef)
+    expect(db.setUserSetting.mock.calls[0][2]).toBe('statsInterval')
+    expect(db.setUserSetting.mock.calls[0][3]).toBe(0)
+    expect(res.send).toHaveBeenCalledAfter(db.setUserSetting)
+  })
 })

--- a/__tests__/stats.test.js
+++ b/__tests__/stats.test.js
@@ -26,4 +26,14 @@ describe('stats blocks', () => {
     const stats = await statsBlocks('T1')
     expect(stats[1].fields[1].text).toMatch(/3 <@test1>/)
   })
+
+  test('does not includes stats interval if user id is not passed', async () => {
+    const stats = await statsBlocks('T1')
+    expect(stats).toHaveLength(3)
+  })
+
+  test('includes default Forever stats interval if nothing else is set', async () => {
+    const stats = await statsBlocks('T1', 'U1234')
+    expect(stats).toHaveLength(4)
+  })
 })

--- a/db.js
+++ b/db.js
@@ -156,13 +156,13 @@ module.exports = {
   /**
    * Returns a list sorted by the shortest winning click times (ascending order).
    */
-  async fastestClickTimes (instanceRef, maxCount) {
+  async fastestClickTimes (instanceRef, maxCount, userRef = null, _currentTime = undefined) {
     const collection = await instanceCollection()
     const instance = await collection.findOne({
       'team.id': instanceRef
     })
 
-    const winningClickTimes = instance.buttons
+    const winningClickTimes = filteredClicks(instance, userRef, _currentTime)
       .map(e => e.clicks && e.clicks[0] ? [e.uuid, e.clicks[0]] : undefined)
       .filter(e => e !== undefined)
       .map(([uuid, { user, timestamp }]) => ({
@@ -473,13 +473,13 @@ module.exports = {
   /**
    * Returns a list sorted by the slowest winning click times (descending order).
    */
-  async slowestClickTimes (instanceRef, maxCount) {
+  async slowestClickTimes (instanceRef, maxCount, userRef = null, _currentTime = undefined) {
     const collection = await instanceCollection()
     const instance = await collection.findOne({
       'team.id': instanceRef
     })
 
-    const winningClickTimes = instance.buttons
+    const winningClickTimes = filteredClicks(instance, userRef, _currentTime)
       .map(e => e.clicks && e.clicks[0] ? [e.uuid, e.clicks[0]] : undefined)
       .filter(e => e !== undefined)
       .map(([uuid, { user, timestamp }]) => ({
@@ -540,7 +540,7 @@ module.exports = {
   /**
    * Returns a list sorted by the longest winning streaks (descending order).
    */
-  async winningStreaks (instanceRef, maxCount) {
+  async winningStreaks (instanceRef, maxCount, userRef = null, _currentTime = undefined) {
     const collection = await instanceCollection()
     const instance = await collection.findOne({
       'team.id': instanceRef
@@ -550,7 +550,7 @@ module.exports = {
     let currentWinner
     let currentStreak
 
-    for (const button of instance.buttons) {
+    for (const button of filteredClicks(instance, userRef, _currentTime)) {
       const winner = button.clicks && button.clicks[0] ? button.clicks[0].user : undefined
       if (winner) {
         if (currentWinner === winner) {

--- a/home.js
+++ b/home.js
@@ -248,7 +248,7 @@ module.exports = {
   async publishHome ({ instanceRef, user }) {
     // Get current settings and stats.
     const instance = await db.instance(instanceRef)
-    const stats = await statsBlocks(instanceRef)
+    const stats = await statsBlocks(instanceRef, user)
 
     // Check if user is admin.
     const isAdmin = instance.authedUser.id === user

--- a/routes.js
+++ b/routes.js
@@ -43,6 +43,7 @@ module.exports = (app, asyncEventHandler) => {
     try {
       const payload = JSON.parse(req.body.payload)
       const instanceRef = payload.team.id
+      const userRef = payload.user.id
 
       if (payload.type === 'block_actions') {
         for (const action of payload.actions) {
@@ -61,6 +62,9 @@ module.exports = (app, asyncEventHandler) => {
               break
             case 'admin_endtime':
               await settings.setEndTime(res, instanceRef, action, asyncEventHandler)
+              break
+            case 'user_stats_interval':
+              await settings.setUserSetting(res, instanceRef, action, userRef, 'statsInterval')
               break
             case 'wild_button':
               await clickCommand(res, payload, asyncEventHandler)

--- a/settings.js
+++ b/settings.js
@@ -47,6 +47,12 @@ module.exports = {
     res.send('')
   },
 
+  async setUserSetting (res, instanceRef, action, userRef, name) {
+    const value = parseInt(action.selected_option.value)
+    await db.setUserSetting(instanceRef, userRef, name, value)
+    res.send('')
+  },
+
   async setWeekdays (res, instanceRef, action, asyncEventHandler) {
     const selectedWeekdays = action.selected_options.map(e => parseInt(e.value))
     const weekdayMask = weekdaysToMask(selectedWeekdays)


### PR DESCRIPTION
As requested by <someone>, it would be nice if the stats could only show the last year of stats, instead of always showing stats for all eternity.

This PR adds support for this.